### PR TITLE
Add service interfaces and xUnit tests

### DIFF
--- a/Shadow2shine.Api/Controllers/ChatGptController.cs
+++ b/Shadow2shine.Api/Controllers/ChatGptController.cs
@@ -1,0 +1,23 @@
+using Microsoft.AspNetCore.Mvc;
+using Shadow2shine.Api.Services;
+
+namespace Shadow2shine.Api.Controllers;
+
+[ApiController]
+[Route("chatgpt")]
+public class ChatGptController : ControllerBase
+{
+    private readonly IChatGptService _service;
+
+    public ChatGptController(IChatGptService service)
+    {
+        _service = service;
+    }
+
+    [HttpPost]
+    public async Task<IActionResult> Ask([FromBody] string prompt)
+    {
+        var response = await _service.AskAsync(prompt);
+        return Ok(new { response });
+    }
+}

--- a/Shadow2shine.Api/Controllers/FfmpegController.cs
+++ b/Shadow2shine.Api/Controllers/FfmpegController.cs
@@ -1,0 +1,33 @@
+using Microsoft.AspNetCore.Mvc;
+using Shadow2shine.Api.Models;
+using Shadow2shine.Api.Services;
+
+namespace Shadow2shine.Api.Controllers;
+
+[ApiController]
+[Route("ffmpeg")]
+public class FfmpegController : ControllerBase
+{
+    private readonly IFfmpegSegmentService _segmentService;
+    private readonly IFfmpegMergeService _mergeService;
+
+    public FfmpegController(IFfmpegSegmentService segmentService, IFfmpegMergeService mergeService)
+    {
+        _segmentService = segmentService;
+        _mergeService = mergeService;
+    }
+
+    [HttpPost("segment")]
+    public async Task<IActionResult> Segment([FromBody] SegmentRequest request)
+    {
+        var file = await _segmentService.SegmentAsync(request);
+        return Ok(new { file });
+    }
+
+    [HttpPost("merge")]
+    public async Task<IActionResult> Merge([FromBody] MergeRequest request)
+    {
+        var file = await _mergeService.MergeAsync(request);
+        return Ok(new { file });
+    }
+}

--- a/Shadow2shine.Api/Controllers/GoogleController.cs
+++ b/Shadow2shine.Api/Controllers/GoogleController.cs
@@ -1,0 +1,24 @@
+using Microsoft.AspNetCore.Mvc;
+using Shadow2shine.Api.Models;
+using Shadow2shine.Api.Services;
+
+namespace Shadow2shine.Api.Controllers;
+
+[ApiController]
+[Route("google")]
+public class GoogleController : ControllerBase
+{
+    private readonly IGoogleTtsService _ttsService;
+
+    public GoogleController(IGoogleTtsService ttsService)
+    {
+        _ttsService = ttsService;
+    }
+
+    [HttpPost("tts")]
+    public async Task<IActionResult> Tts([FromBody] TtsRequest request)
+    {
+        var file = await _ttsService.SynthesizeSpeechAsync(request);
+        return Ok(new { file });
+    }
+}

--- a/Shadow2shine.Api/Models/MergeRequest.cs
+++ b/Shadow2shine.Api/Models/MergeRequest.cs
@@ -1,0 +1,7 @@
+namespace Shadow2shine.Api.Models;
+
+public class MergeRequest
+{
+    public List<string> InputFiles { get; set; } = new();
+    public string? OutputFile { get; set; }
+}

--- a/Shadow2shine.Api/Models/SegmentRequest.cs
+++ b/Shadow2shine.Api/Models/SegmentRequest.cs
@@ -1,0 +1,8 @@
+namespace Shadow2shine.Api.Models;
+
+public class SegmentRequest
+{
+    public string InputFile { get; set; } = string.Empty;
+    public TimeSpan Start { get; set; }
+    public TimeSpan Duration { get; set; }
+}

--- a/Shadow2shine.Api/Models/TtsRequest.cs
+++ b/Shadow2shine.Api/Models/TtsRequest.cs
@@ -1,0 +1,6 @@
+namespace Shadow2shine.Api.Models;
+
+public class TtsRequest
+{
+    public string Text { get; set; } = string.Empty;
+}

--- a/Shadow2shine.Api/Program.cs
+++ b/Shadow2shine.Api/Program.cs
@@ -1,0 +1,32 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Shadow2shine.Api.Services;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddControllers();
+
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen();
+
+// register services
+builder.Services.AddScoped<IChatGptService, ChatGptService>();
+builder.Services.AddScoped<IGoogleTtsService, GoogleTtsService>();
+builder.Services.AddScoped<IFfmpegSegmentService, FfmpegSegmentService>();
+builder.Services.AddScoped<IFfmpegMergeService, FfmpegMergeService>();
+builder.Services.AddScoped<IShadowingOrchestrator, ShadowingOrchestrator>();
+
+var app = builder.Build();
+
+if (app.Environment.IsDevelopment())
+{
+    app.UseSwagger();
+    app.UseSwaggerUI();
+}
+
+app.UseAuthorization();
+
+app.MapControllers();
+
+app.Run();

--- a/Shadow2shine.Api/Services/ChatGptService.cs
+++ b/Shadow2shine.Api/Services/ChatGptService.cs
@@ -1,0 +1,10 @@
+namespace Shadow2shine.Api.Services;
+
+public class ChatGptService : IChatGptService
+{
+    public Task<string> AskAsync(string prompt)
+    {
+        // placeholder implementation
+        return Task.FromResult($"Echo: {prompt}");
+    }
+}

--- a/Shadow2shine.Api/Services/FfmpegMergeService.cs
+++ b/Shadow2shine.Api/Services/FfmpegMergeService.cs
@@ -1,0 +1,13 @@
+using Shadow2shine.Api.Models;
+
+namespace Shadow2shine.Api.Services;
+
+public class FfmpegMergeService : IFfmpegMergeService
+{
+    public Task<string> MergeAsync(MergeRequest request)
+    {
+        // placeholder implementation
+        var output = request.OutputFile ?? "merged_output.mp3";
+        return Task.FromResult(output);
+    }
+}

--- a/Shadow2shine.Api/Services/FfmpegSegmentService.cs
+++ b/Shadow2shine.Api/Services/FfmpegSegmentService.cs
@@ -1,0 +1,13 @@
+using Shadow2shine.Api.Models;
+
+namespace Shadow2shine.Api.Services;
+
+public class FfmpegSegmentService : IFfmpegSegmentService
+{
+    public Task<string> SegmentAsync(SegmentRequest request)
+    {
+        // placeholder implementation
+        var output = $"segment_{request.InputFile}";
+        return Task.FromResult(output);
+    }
+}

--- a/Shadow2shine.Api/Services/GoogleTtsService.cs
+++ b/Shadow2shine.Api/Services/GoogleTtsService.cs
@@ -1,0 +1,13 @@
+using Shadow2shine.Api.Models;
+
+namespace Shadow2shine.Api.Services;
+
+public class GoogleTtsService : IGoogleTtsService
+{
+    public Task<string> SynthesizeSpeechAsync(TtsRequest request)
+    {
+        // placeholder implementation
+        var output = $"tts_{request.Text.Replace(' ', '_')}.mp3";
+        return Task.FromResult(output);
+    }
+}

--- a/Shadow2shine.Api/Services/IChatGptService.cs
+++ b/Shadow2shine.Api/Services/IChatGptService.cs
@@ -1,0 +1,6 @@
+namespace Shadow2shine.Api.Services;
+
+public interface IChatGptService
+{
+    Task<string> AskAsync(string prompt);
+}

--- a/Shadow2shine.Api/Services/IFfmpegMergeService.cs
+++ b/Shadow2shine.Api/Services/IFfmpegMergeService.cs
@@ -1,0 +1,8 @@
+using Shadow2shine.Api.Models;
+
+namespace Shadow2shine.Api.Services;
+
+public interface IFfmpegMergeService
+{
+    Task<string> MergeAsync(MergeRequest request);
+}

--- a/Shadow2shine.Api/Services/IFfmpegSegmentService.cs
+++ b/Shadow2shine.Api/Services/IFfmpegSegmentService.cs
@@ -1,0 +1,8 @@
+using Shadow2shine.Api.Models;
+
+namespace Shadow2shine.Api.Services;
+
+public interface IFfmpegSegmentService
+{
+    Task<string> SegmentAsync(SegmentRequest request);
+}

--- a/Shadow2shine.Api/Services/IGoogleTtsService.cs
+++ b/Shadow2shine.Api/Services/IGoogleTtsService.cs
@@ -1,0 +1,8 @@
+using Shadow2shine.Api.Models;
+
+namespace Shadow2shine.Api.Services;
+
+public interface IGoogleTtsService
+{
+    Task<string> SynthesizeSpeechAsync(TtsRequest request);
+}

--- a/Shadow2shine.Api/Services/IShadowingOrchestrator.cs
+++ b/Shadow2shine.Api/Services/IShadowingOrchestrator.cs
@@ -1,0 +1,6 @@
+namespace Shadow2shine.Api.Services;
+
+public interface IShadowingOrchestrator
+{
+    Task<string> RunAsync(string prompt);
+}

--- a/Shadow2shine.Api/Services/ShadowingOrchestrator.cs
+++ b/Shadow2shine.Api/Services/ShadowingOrchestrator.cs
@@ -1,0 +1,27 @@
+namespace Shadow2shine.Api.Services;
+
+public class ShadowingOrchestrator : IShadowingOrchestrator
+{
+    private readonly IChatGptService _chatGpt;
+    private readonly IGoogleTtsService _tts;
+    private readonly IFfmpegSegmentService _segment;
+    private readonly IFfmpegMergeService _merge;
+
+    public ShadowingOrchestrator(IChatGptService chatGpt, IGoogleTtsService tts, IFfmpegSegmentService segment, IFfmpegMergeService merge)
+    {
+        _chatGpt = chatGpt;
+        _tts = tts;
+        _segment = segment;
+        _merge = merge;
+    }
+
+    // placeholder orchestrator logic
+    public async Task<string> RunAsync(string prompt)
+    {
+        var reply = await _chatGpt.AskAsync(prompt);
+        var ttsFile = await _tts.SynthesizeSpeechAsync(new Models.TtsRequest { Text = reply });
+        var segmentFile = await _segment.SegmentAsync(new Models.SegmentRequest { InputFile = ttsFile });
+        var merged = await _merge.MergeAsync(new Models.MergeRequest { InputFiles = new() { segmentFile }, OutputFile = "final.mp3" });
+        return merged;
+    }
+}

--- a/Shadow2shine.Api/Shadow2shine.Api.csproj
+++ b/Shadow2shine.Api/Shadow2shine.Api.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+</Project>

--- a/Shadow2shine.Tests/Controllers/ChatGptControllerTests.cs
+++ b/Shadow2shine.Tests/Controllers/ChatGptControllerTests.cs
@@ -1,0 +1,22 @@
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Shadow2shine.Api.Controllers;
+using Shadow2shine.Api.Services;
+using Xunit;
+
+public class ChatGptControllerTests
+{
+    [Fact]
+    public async Task Ask_Returns_Echo()
+    {
+        IChatGptService service = new ChatGptService();
+        var controller = new ChatGptController(service);
+
+        var result = await controller.Ask("hello");
+        var ok = Assert.IsType<OkObjectResult>(result);
+        var value = ok.Value;
+        var prop = value?.GetType().GetProperty("response");
+        var response = prop?.GetValue(value) as string;
+        Assert.Equal("Echo: hello", response);
+    }
+}

--- a/Shadow2shine.Tests/Services/ShadowingOrchestratorTests.cs
+++ b/Shadow2shine.Tests/Services/ShadowingOrchestratorTests.cs
@@ -1,0 +1,21 @@
+using System.Threading.Tasks;
+using Shadow2shine.Api.Services;
+using Xunit;
+
+public class ShadowingOrchestratorTests
+{
+    [Fact]
+    public async Task RunAsync_Returns_FinalMp3()
+    {
+        IChatGptService chatGpt = new ChatGptService();
+        IGoogleTtsService tts = new GoogleTtsService();
+        IFfmpegSegmentService segment = new FfmpegSegmentService();
+        IFfmpegMergeService merge = new FfmpegMergeService();
+
+        IShadowingOrchestrator orchestrator = new ShadowingOrchestrator(chatGpt, tts, segment, merge);
+
+        var result = await orchestrator.RunAsync("test");
+
+        Assert.Equal("final.mp3", result);
+    }
+}

--- a/Shadow2shine.Tests/Shadow2shine.Tests.csproj
+++ b/Shadow2shine.Tests/Shadow2shine.Tests.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Shadow2shine.Api\Shadow2shine.Api.csproj" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
## Summary
- introduce interfaces for all service classes
- inject controllers using service interfaces
- wire up DI with interfaces in Program.cs
- add xUnit test project for controller and orchestrator

## Testing
- `dotnet test Shadow2shine.Tests/Shadow2shine.Tests.csproj -c Release` *(fails: command not found)*
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687cf5ceb04c832daf7d99433b31f90d